### PR TITLE
fix: sync dispatch-review.yaml to corrected canonical template

### DIFF
--- a/.config/cspell/project.txt
+++ b/.config/cspell/project.txt
@@ -9,6 +9,7 @@ ccresume
 abhinav
 
 # Homebrew terms
+libexec
 livecheck
 metaformula
 postflight
@@ -56,6 +57,7 @@ stefanzweifel
 
 # App names
 Spokenly
+customizer
 gsettings
 dconf
 xdotool

--- a/.github/workflows/dispatch-review.yaml
+++ b/.github/workflows/dispatch-review.yaml
@@ -30,15 +30,7 @@ name: Dispatch PR Review
 
 on:
   pull_request:
-    types:
-      [
-        opened,
-        reopened,
-        synchronize,
-        ready_for_review,
-        labeled,
-        converted_to_draft,
-      ]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, converted_to_draft]
 
 jobs:
   review:

--- a/.github/workflows/dispatch-review.yaml
+++ b/.github/workflows/dispatch-review.yaml
@@ -30,7 +30,15 @@ name: Dispatch PR Review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, labeled, converted_to_draft]
+    types:
+      [
+        opened,
+        reopened,
+        synchronize,
+        ready_for_review,
+        labeled,
+        converted_to_draft,
+      ]
 
 jobs:
   review:

--- a/.github/workflows/dispatch-review.yaml
+++ b/.github/workflows/dispatch-review.yaml
@@ -34,15 +34,21 @@ on:
 
 jobs:
   review:
-    # Gate at the template level (post-2026-05-23 redesign): only dispatch
-    # when the PR is open AND carries the request-review label. The
-    # `converted_to_draft` event also fires (PR is still in state=open while
-    # draft) so the receiver can short-circuit with a `neutral` check rather
-    # than running a review on a drafted PR. If you change the request label
-    # name, update the literal in the `contains(...)` expression below.
+    # Gate: review fires automatically on any OPEN, non-draft PR event
+    # (opened, reopened, synchronize, ready_for_review) -- no label needed.
+    # The `request-review` label only matters to FORCE a review on a DRAFT
+    # PR (apply the label while it's still a draft). `converted_to_draft` is
+    # let through unconditionally so the receiver can short-circuit with a
+    # `neutral` check instead of leaving a stale pending check-run. If you
+    # change the request label name, update the literal in the `==`
+    # comparison below.
     if: |
       github.event.pull_request.state == 'open' &&
-      contains(github.event.pull_request.labels.*.name, 'request-review')
+      (
+        github.event.pull_request.draft != true ||
+        github.event.action == 'converted_to_draft' ||
+        (github.event.action == 'labeled' && github.event.label.name == 'request-review')
+      )
     # Explicit permissions: default_workflow_permissions is "read" in many
     # repos but the called workflow needs pull-requests + checks write.
     permissions:

--- a/.github/workflows/dispatch-review.yaml
+++ b/.github/workflows/dispatch-review.yaml
@@ -30,23 +30,22 @@ name: Dispatch PR Review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, labeled, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
 
 jobs:
   review:
     # Gate: review fires automatically on any OPEN, non-draft PR event
     # (opened, reopened, synchronize, ready_for_review) -- no label needed.
     # The `request-review` label only matters to FORCE a review on a DRAFT
-    # PR (apply the label while it's still a draft). `converted_to_draft` is
-    # let through unconditionally so the receiver can short-circuit with a
-    # `neutral` check instead of leaving a stale pending check-run. If you
-    # change the request label name, update the literal in the `==`
+    # PR (apply the label while it's still a draft). `converted_to_draft`
+    # does NOT fire a review by itself -- a PR converted to draft is simply
+    # not reviewed until it's marked ready again or explicitly labeled. If
+    # you change the request label name, update the literal in the `==`
     # comparison below.
     if: |
       github.event.pull_request.state == 'open' &&
       (
         github.event.pull_request.draft != true ||
-        github.event.action == 'converted_to_draft' ||
         (github.event.action == 'labeled' && github.event.label.name == 'request-review')
       )
     # Explicit permissions: default_workflow_permissions is "read" in many

--- a/.github/workflows/dispatch-review.yaml
+++ b/.github/workflows/dispatch-review.yaml
@@ -30,15 +30,7 @@ name: Dispatch PR Review
 
 on:
   pull_request:
-    types:
-      [
-        opened,
-        reopened,
-        synchronize,
-        ready_for_review,
-        labeled,
-        converted_to_draft,
-      ]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, converted_to_draft]
 
 jobs:
   review:
@@ -61,7 +53,7 @@ jobs:
     # on the next PR event in repos using this template. This is intentional —
     # operators who need pinned stability should replace @main with a commit SHA
     # and update it in lock-step with plugin version bumps.
-    uses: nsheaps/agents/.github/workflows/review-dispatch.yaml@b687f7fcf22413267432ffc867bc51af569cf7d8 # main
+    uses: nsheaps/agents/.github/workflows/review-dispatch.yaml@main
     # secrets: inherit doesn't pass cross-repo (GitHub limitation).
     secrets:
       AUTOMATION_GITHUB_APP_ID: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}

--- a/.github/workflows/pr-status-dispatch.yaml
+++ b/.github/workflows/pr-status-dispatch.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Authenticate as GitHub App
         id: app-token
-        uses: nsheaps/github-actions/.github/actions/github-app-auth@main
+        uses: nsheaps/github-actions/.github/actions/github-app-auth@c1794f6f4fbb3cbc5e5a71e820581a74239f706a # main
         with:
           app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-status-dispatch.yaml
+++ b/.github/workflows/pr-status-dispatch.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Authenticate as GitHub App
         id: app-token
-        uses: nsheaps/github-actions/.github/actions/github-app-auth@c1794f6f4fbb3cbc5e5a71e820581a74239f706a # main
+        uses: nsheaps/github-actions/.github/actions/github-app-auth@main
         with:
           app-id: ${{ secrets.AUTOMATION_GITHUB_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_GITHUB_APP_PRIVATE_KEY }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Centrally synced from nsheaps/.github (ansible/templates/.github/workflows/) —
+# must stay byte-identical to the canonical template, so local formatting
+# must not touch it. See the sync-dispatch-workflows skill in
+# nsheaps/agents/plugins/claude-code/review-utils for the mechanism.
+.github/workflows/dispatch-review.yaml


### PR DESCRIPTION
## Summary

Five fixes on this branch, all to `.github/workflows/dispatch-review.yaml` (plus one incidental dictionary fix):

1. **Initial drift fix**: `on.pull_request.types` was reformatted into a multi-line list and the `nsheaps/agents/.github/workflows/review-dispatch.yaml` ref was pinned to a commit SHA instead of tracking `@main`.
2. **Durable prettier fix**: the repo's `mise run format` (prettier, no `.prettierignore`) was re-wrapping the canonical template's single-line `types` array on every CI run, undoing fix #1 each time. Added `.prettierignore` excluding this centrally-synced file from local formatting.
3. **Gate correction** (this repo picking up a canonical template change): the review-dispatch gate previously required the `request-review` label on *every* open PR event — inconsistent with `nsheaps/ai-mktpl`'s own working review workflow, and that label was never centrally provisioned, so the gate was effectively inert. New gate: `state == 'open' && (draft != true || (action == 'labeled' && label == 'request-review'))` — reviews now fire automatically on any open, non-draft PR event; the label only matters to force a review on a still-draft PR. The label is now provisioned org-wide via `nsheaps/.github`'s `org-labels.yaml`.
4. **Merge conflict resolved**: this repo's `main` had a direct-push fix applied earlier in this session, but `nsheaps/.github`'s `sync-all.yaml` automation ran again (weekly cron or similar) and overwrote it with the *old*, still-broken canonical template — since #198 (which has the fix) hasn't merged into `nsheaps/.github` yet, the "live" canonical source it syncs from is still the unfixed template. That direct push also wiped out `.prettierignore` and re-wrote `dispatch-review.yaml` back to the broken gate + a SHA-pinned `uses:` (from a separate renovate-style pin bot). Merged `main` into this branch and resolved in favor of this branch's corrected gate + unpinned `@main` ref — confirmed byte-identical to the canonical template again after resolution. (Checked: this is specific to this repo, since it's the only one that had a direct-to-main fix to get clobbered — the other companion PRs' target repos never had `main` fixed directly, so there's nothing there for the automation to regress.)
5. **cspell dictionary fix**: merging in `main`'s latest state pulled in `Formula/dotfiles.rb` and `Casks/nsheaps-base.rb` content (from unrelated renovate commits) using `libexec`/`customizer`, words missing from `.config/cspell/project.txt`. Added both — confirmed clean with a local `cspell` run.

`pr-status-dispatch.yaml` is out of scope — separate, unrelated mechanism (an earlier commit touched it by mistake and was reverted).

## Test plan

- [x] `.github/workflows/dispatch-review.yaml` diffed byte-for-byte against `nsheaps/.github/ansible/templates/.github/workflows/dispatch-review.yaml` — identical (re-confirmed after the merge conflict resolution)
- [x] `.prettierignore` confirmed present and covering this path (survived the merge)
- [x] Confirmed `pr-status-dispatch.yaml` is unchanged from its original content
- [x] `npx cspell Formula/dotfiles.rb Casks/nsheaps-base.rb` — 0 issues after the dictionary fix
- [ ] CI passes (note: `Security` job's grype cache-save step is pre-existing-flaky on `main` too — a `tar` error saving the vulnerability-db cache, unrelated to this diff; the actual scan itself reports 0 vulnerabilities — see PR comments)