### PR TITLE
Add top-level permissions block to dispatch-review.yaml

### DIFF
--- a/.github/workflows/dispatch-review.yaml
+++ b/.github/workflows/dispatch-review.yaml
@@ -32,6 +32,13 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, labeled]
 
+# Explicit top-level permissions (mirrors the job-level grant below) so
+# checkov's CKV2_GHA_1 ("top-level permissions not write-all") is satisfied.
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
 jobs:
   review:
     # Gate: review fires automatically on any OPEN, non-draft PR event


### PR DESCRIPTION
## Summary

- `checkov`'s `CKV2_GHA_1` ("Ensure top-level permissions are not set to write-all") was flagging `dispatch-review.yaml` because it only declares `permissions:` at the job level, not the workflow (top) level.
- Added an explicit top-level `permissions:` block that exactly mirrors the existing job-level grant (`contents: read`, `pull-requests: write`, `checks: write`) — no behavior change, purely satisfies the check.

## Why now

This was the last remaining `checkov` finding blocking `check.yaml`'s `Security` job on `main`, after `nsheaps/.github#205` fixed the other one (`CKV_GHA_7` on `apply-repo-settings.yaml`). Both were pre-existing and unrelated to `nsheaps/homebrew-devsetup#693` (the last open item in the `ci-workflows-dynamic-sync-rtdzqw` rollout), which has been blocked on `main` recovering.

Same fix already validated on `#693`'s branch directly, where it cleared this exact finding.

## Test plan

- [ ] `checkov` passes on `dispatch-review.yaml` after this change
- [ ] `dispatch-review.yaml`'s actual behavior is unchanged — permissions match what the job already declared


---
_Generated by [Claude Code](https://claude.ai/code/session_0189AKpyNKFsnJbgoMfb31DN)_